### PR TITLE
Adicionado site de tradução pt-br para jogos

### DIFF
--- a/docs/jogos-piratas.md
+++ b/docs/jogos-piratas.md
@@ -54,6 +54,14 @@ Esses são buscadores fáceis para encontrar seus jogos:
 - [Hatt](https://github.com/FrenchGithubUser/Hatt) - Aplicativo de mecanismo de pesquisa DDL.
 
 ---
+## Traduções de Jogos
+Esses são alguns site para encotrar tradução PT-BR para seus jogos:
+
+- [GAMEVICIO](https://www.gamevicio.com/traducoes/) - [Resultados de segurança da URL](https://www.urlvoid.com/scan/gamevicio.com/)
+- [Central de Traduções](https://www.centraldetraducoes.net.br/) - [Resultados de segurança da URL](https://www.urlvoid.com/scan/centraldetraducoes.net.br/)
+- [Forum Hardmob](https://www.hardmob.com.br/threads/130505-Traducoes-de-Jogos) - [Resultados de segurança da URL](https://www.urlvoid.com/scan/hardmob.com.br/)
+  
+---
 ## Sites Torrent
 Torrents são downloads P2P – você baixa de outras pessoas que baixaram o arquivo. Nenhum servidor está envolvido.
 Para obter uma lista de uploaders dos quais você deve ficar longe, verifique a seção [Uploaders não confiaveis](https://gnireorb.github.io/pirataria/Jogos-Piratas#sites-n%C3%A3o-confi%C3%A1veis).

--- a/docs/jogos.md
+++ b/docs/jogos.md
@@ -6,6 +6,14 @@ Os jogos requerem interação com uma interface de usuário ou dispositivo de en
 - 🐐 = Altamente recomendado pela comunidade pirata.
 
 ---
+## Traduções de Jogos
+Esses são alguns site para encotrar tradução PT-BR para seus jogos:
+
+- [GAMEVICIO](https://www.gamevicio.com/traducoes/) - [Resultados de segurança da URL](https://www.urlvoid.com/scan/gamevicio.com/)
+- [Central de Traduções](https://www.centraldetraducoes.net.br/) - [Resultados de segurança da URL](https://www.urlvoid.com/scan/centraldetraducoes.net.br/)
+- [Forum Hardmob](https://www.hardmob.com.br/threads/130505-Traducoes-de-Jogos) - [Resultados de segurança da URL](https://www.urlvoid.com/scan/hardmob.com.br/)
+  
+---
 ## 📑 1 ➜ Downloads diretos
 
 ### 🐐 [CS.RIN.RU: Steam Underground](https://cs.rin.ru/forum/) • Cadastre-se


### PR DESCRIPTION
Adicionei apenas alguns sites para traduzir jogos para pt-br
Nome: GAMEVICIO | URL: https://www.gamevicio.com/traducoes/
![image](https://github.com/c-pirataria/megathread/assets/68130641/b7d740c2-02ea-4c02-89c6-d418646244c7)

Nome: Central de Traduções | URL: https://www.centraldetraducoes.net.br/
![image](https://github.com/c-pirataria/megathread/assets/68130641/6268180a-008e-416a-b572-1d56576112b9)

Nome: Traduções de Jogos | URL: https://www.hardmob.com.br/threads/130505-Traducoes-de-Jogos
![image](https://github.com/c-pirataria/megathread/assets/68130641/c753587a-28aa-4c2c-b1bd-f2af251c4fcd)
