### PR TITLE
Patch Novo Método de Download CDRomance

### DIFF
--- a/docs/pages/emuladores-roms.md
+++ b/docs/pages/emuladores-roms.md
@@ -244,10 +244,10 @@ Os emuladores simulam as ações dos consoles de jogos, enquanto as ROMs são c�
 - 180 jogos fantásticos. Basta baixar e extrair o arquivo zip de 19 MB.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/archive.org/)
 
-### 🔗 [CDRomance](https://cdromance.com/) e [Tickets](https://cdromance.org/)
+### 🔗 [CDRomance](https://cdromance.com/) e [Página de Tickets](https://cdromance.org/)
 
 - Coleção de jogos da era de 128 bits da sexta geração de consoles, bem como títulos de 8 bits.
-- UPDATE: A partir do dia 10/02, os downloads diretos foram desativados. Agora requer copiar código TCR do rom desejado e colar na página de tickets.   
+- UPDATE: Os downloads diretos foram desativados. Agora é necessário copiar o código CDR_TICKET do arquivo desejado e colar na página de tickets.   
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/cdromance.com/) 
 
 ### 🔗 [Cylum's Sega Master System ROM Collection](https://archive.org/details/cylums-sega-master-system-rom-collection)

--- a/docs/pages/emuladores-roms.md
+++ b/docs/pages/emuladores-roms.md
@@ -244,10 +244,11 @@ Os emuladores simulam as ações dos consoles de jogos, enquanto as ROMs são c�
 - 180 jogos fantásticos. Basta baixar e extrair o arquivo zip de 19 MB.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/archive.org/)
 
-### 🔗 [CDRomance](https://cdromance.com/)
+### 🔗 [CDRomance](https://cdromance.com/) e [Tickets](https://cdromance.org/)
 
 - Coleção de jogos da era de 128 bits da sexta geração de consoles, bem como títulos de 8 bits.
-- [Resultados de segurança da URL](https://www.urlvoid.com/scan/cdromance.com/)
+- UPDATE: A partir do dia 10/02, os downloads diretos foram desativados. Agora requer copiar código TCR do rom desejado e colar na página de tickets.   
+- [Resultados de segurança da URL](https://www.urlvoid.com/scan/cdromance.com/) 
 
 ### 🔗 [Cylum's Sega Master System ROM Collection](https://archive.org/details/cylums-sega-master-system-rom-collection)
 

--- a/docs/pages/emuladores-roms.md
+++ b/docs/pages/emuladores-roms.md
@@ -245,10 +245,12 @@ Os emuladores simulam as ações dos consoles de jogos, enquanto as ROMs são c�
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/archive.org/)
 
 ### 🔗 [CDRomance](https://cdromance.com/) e [Página de Tickets](https://cdromance.org/)
+:::warning ⚠️ Preste Atenção
 
+Os downloads diretos foram desativados. Agora é necessário copiar o código CDR_TICKET do arquivo desejado e colar na página de tickets.
+  :::   
 - Coleção de jogos da era de 128 bits da sexta geração de consoles, bem como títulos de 8 bits.
-- UPDATE: Os downloads diretos foram desativados. Agora é necessário copiar o código CDR_TICKET do arquivo desejado e colar na página de tickets.   
-- [Resultados de segurança da URL](https://www.urlvoid.com/scan/cdromance.com/) 
+- Resultados de segurança da URL: [1](https://www.urlvoid.com/scan/cdromance.com/) / [2](https://www.urlvoid.com/scan/cdromance.org/)
 
 ### 🔗 [Cylum's Sega Master System ROM Collection](https://archive.org/details/cylums-sega-master-system-rom-collection)
 


### PR DESCRIPTION
A partir de 10/02, o site CDRomance retirou todos os links de download direto. O site antigo tornou-se apenas para consultar o CDR_TICKET enquanto o download fica na nova página: cdromance.org