### PR TITLE
Mudança de Licença: Projeto Megathread Pirata agora sob a WTFPL

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,24 +1,13 @@
-This is free and unencumbered software released into the public domain.
+            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+                    Version 2, December 2004
 
-Anyone is free to copy, modify, publish, use, compile, sell, or
-distribute this software, either in source code form or as a compiled
-binary, for any purpose, commercial or non-commercial, and by any
-means.
+ Copyright (C) 2024 Comunidade Pirataria Digital <comunidade@pirataria.digital>
 
-In jurisdictions that recognize copyright laws, the author or authors
-of this software dedicate any and all copyright interest in the
-software to the public domain. We make this dedication for the benefit
-of the public at large and to the detriment of our heirs and
-successors. We intend this dedication to be an overt act of
-relinquishment in perpetuity of all present and future rights to this
-software under copyright law.
+ Everyone is permitted to copy and distribute verbatim or modified
+ copies of this license document, and changing it is allowed as long
+ as the name is changed.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
+            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
-For more information, please refer to <http://unlicense.org/>
+  0. You just DO WHAT THE FUCK YOU WANT TO.

--- a/README.md
+++ b/README.md
@@ -5,30 +5,30 @@
 
 # O que são as Megathreads?
 
-As megathreads são tópicos específicos que agrupam informações relevantes em um único local. Elas ajudam a manter a comunidade organizada e proporcionam um acesso fácil a recursos e atualizações relacionadas a um determinado tópico. Nossas megathreads são mantidas neste repositório para facilitar o acompanhamento e a colaboração.
+As Megathreads são tópicos específicos que agrupam informações relevantes em um único local. Elas ajudam a manter a comunidade organizada e proporcionam um acesso fácil a recursos e atualizações relacionadas a um determinado tópico. Nossa megathread é mantida neste repositório para facilitar o acompanhamento e a contribuição.
 
 ## Conteúdo do Repositório
 
-Este repositório contém os arquivos Markdown das nossas Megathreads. Cada arquivo Markdown corresponde a uma megathread específica e inclui:
+Este repositório contém os arquivos [Markdown](https://www.markdownguide.org/) da nossa Megathread. Cada arquivo Markdown corresponde a uma página específica e inclui:
 
-- Informações gerais sobre o tópico da Megathread.
+- Informações gerais sobre o tópico da página.
 - Links para recursos relevantes.
 
 ## Contribuição
 
-Nossa comunidade é bem-vinda para contribuir na manutenção e atualização das Megathreads. Se você deseja contribuir, siga os seguintes passos:
+Nossa comunidade é bem-vinda para contribuir na manutenção e atualização da Megathread. Se você deseja contribuir, siga os seguintes passos:
 
-1. Faça um fork deste repositório para o seu perfil GitHub.
+1. Faça um [fork](https://github.com/c-pirataria/megathread/fork) deste repositório para o seu perfil GitHub.
 2. Crie uma nova branch para suas alterações.
-3. Faça as edições necessárias nos arquivos Markdown, situados na pasta [docs/pages](https://github.com/c-pirataria/megathread/tree/main/docs/pages).
+3. Faça as edições necessárias nos arquivos Markdown, situado na pasta docs/pages.
 4. Envie um pull request para este repositório principal.
 5. Explique quais mudanças e adições você fez e por qual motivo aquela mudança ou adição seria interessante.
-6. De preferência que seja um site nacional, mas se for um site gringo está bom.
+6. De preferência que seja um site nacional, mas se for um site gringo está de bom agrado.
 7. Evite causar danos para minorias, como desenvolvedores de jogos indies, por exemplo.
 8. Verificar os sites e links antes de enviar o pull request, por exemplo, reputação do site (procurar no Reddit e outras redes), idade do domínio, etc.
 9. O site não pode conter avisos no [URL Void](https://www.urlvoid.com/), se o site tiver falso positivos explique por que é um falso positivo.
 
-Agradecemos a participação de todos na construção e manutenção de nossas megathreads.
+Agradecemos a participação de todos na construção e manutenção de nossa megathread.
 
 ## Parcerias
 
@@ -36,9 +36,9 @@ Atualmente, o projeto não possui parcerias estabelecidas com outras entidades o
 
 Esta decisão foi tomada após uma cuidadosa avaliação das necessidades atuais do projeto e de nossa capacidade de gerenciar de forma eficaz.
 
-## Vitepress
+## Recursos usados
 
-A Megathread atualmente roda no [Vitepress](https://vitepress.dev/) com o tema [FMHY](https://github.com/fmhy/FMHYedit).
+A Megathread atualmente roda no [Vitepress](https://vitepress.dev/) com o tema [FMHY](https://github.com/fmhy/FMHYedit). 💖
 
 ## Licença
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Este repositório contém os arquivos Markdown das nossas Megathreads. Cada arqu
 - Informações gerais sobre o tópico da Megathread.
 - Links para recursos relevantes.
 
-## Colaboração
+## Contribuição
 
-Nossa comunidade é bem-vinda para colaborar na manutenção e atualização das Megathreads. Se você deseja contribuir, siga os seguintes passos:
+Nossa comunidade é bem-vinda para contribuir na manutenção e atualização das Megathreads. Se você deseja contribuir, siga os seguintes passos:
 
 1. Faça um fork deste repositório para o seu perfil GitHub.
 2. Crie uma nova branch para suas alterações.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Megathread Pirata
+<h1 align="center">Megathread Pirata</h1>
 <div align="center">
     <a href="https://p.lemmy.dbzer0.com/"><img alt="Lemmy" src="https://img.shields.io/lemmy/pirataria%40lemmy.dbzer0.com"></a>
 </div>
@@ -20,14 +20,26 @@ Nossa comunidade é bem-vinda para colaborar na manutenção e atualização das
 
 1. Faça um fork deste repositório para o seu perfil GitHub.
 2. Crie uma nova branch para suas alterações.
-3. Faça as edições necessárias nos arquivos Markdown, situados na pasta docs.
+3. Faça as edições necessárias nos arquivos Markdown, situados na pasta [docs/pages](https://github.com/c-pirataria/megathread/tree/main/docs/pages).
 4. Envie um pull request para este repositório principal.
 5. Explique quais mudanças e adições você fez e por qual motivo aquela mudança ou adição seria interessante.
 6. De preferência que seja um site nacional, mas se for um site gringo está bom.
-7. O site não pode conter avisos no [URL Void](https://www.urlvoid.com/), se o site tiver falso positivos explique por que é um falso positivo.
+7. Evite causar danos para minorias, como desenvolvedores de jogos indies, por exemplo.
+8. Verificar os sites e links antes de enviar o pull request, por exemplo, reputação do site (procurar no Reddit e outras redes), idade do domínio, etc.
+9. O site não pode conter avisos no [URL Void](https://www.urlvoid.com/), se o site tiver falso positivos explique por que é um falso positivo.
 
 Agradecemos a participação de todos na construção e manutenção de nossas megathreads.
 
+## Parcerias
+
+Atualmente, o projeto não possui parcerias estabelecidas com outras entidades ou organizações. Além disso, não estamos aceitando novos colaboradores para o projeto neste momento. O projeto é mantido por atualmente 4 (quatro) colaboradores, os mesmos que fundaram a Comunidade Pirataria.
+
+Esta decisão foi tomada após uma cuidadosa avaliação das necessidades atuais do projeto e de nossa capacidade de gerenciar de forma eficaz.
+
 ## Vitepress
 
-A Megathread atualmente roda no [Vitepress](https://vitepress.dev/) com o tema [FMHY](https://github.com/fmhy/FMHYedit/blob/main/.vitepress/theme/style.css).
+A Megathread atualmente roda no [Vitepress](https://vitepress.dev/) com o tema [FMHY](https://github.com/fmhy/FMHYedit).
+
+## Licença
+
+Este projeto é licenciado sob a WTFPL (Do What The Fuck You Want To Public License). Veja o arquivo [LICENSE](https://github.com/c-pirataria/megathread/blob/main/LICENSE) para mais detalhes.


### PR DESCRIPTION
Olá a todos os colaboradores, contribuidores e usuários do projeto Megathread Pirata, também conhecido como [pirataria.digital](https://pirataria.digital),

Gostaríamos de informar que fizemos uma mudança na licença do projeto. Anteriormente licenciado sob a Unlicense, decidimos mudar para a WTFPL (Do What The Fuck You Want To Public License) para oferecer uma abordagem ainda mais permissiva em relação ao uso e distribuição do código-fonte.

A WTFPL é uma licença extremamente liberal que permite a todos fazerem o que quiserem com o código, sem restrições significativas. Acreditamos que essa mudança reflete melhor nossos valores de liberdade e colaboração aberta.

Todos os detalhes sobre a WTFPL podem ser encontrados no arquivo de licença atualizado no repositório do projeto.

Obrigado,
Equipe Comunidade Pirataria 🏴‍☠️.