### PR TITLE
Mundaças no Filmes e TV + Software + Jogos

### DIFF
--- a/docs/pages/filmes-tv.md
+++ b/docs/pages/filmes-tv.md
@@ -20,6 +20,7 @@ Filmes e TV são obras de arte visual que empregam imagens em movimento para imi
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/braflix.video/)
 
 ### ▶️ [TudoHD](https://tudohd.online/)
+
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/tudohd.online/)
 
 ### ▶️ [Mega Filmes HD](https://www.megafilmeshds.net/)

--- a/docs/pages/filmes-tv.md
+++ b/docs/pages/filmes-tv.md
@@ -119,9 +119,17 @@ Filmes e TV são obras de arte visual que empregam imagens em movimento para imi
 
 ## 🧲 Torrents
 
-### 🌟 [Comando.la](https://comando.la/)
+### 🌟 [Comando](https://comando.la/)
 
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/comando.la/)
+
+### 🌟 [BluDV](https://bludv.xyz/)
+
+- [Resultados de segurança da URL](https://www.urlvoid.com/scan/bludv.xyz/)
+
+### 🧲 [Torrent dos Filmes.site](https://torrentdosfilmes.site/)
+
+- [Resultados de segurança da URL](https://www.urlvoid.com/scan/torrentdosfilmes.site/)
 
 ### 🧲 [Rede Torrent](https://redetorrent.com/)
 

--- a/docs/pages/filmes-tv.md
+++ b/docs/pages/filmes-tv.md
@@ -19,6 +19,9 @@ Filmes e TV são obras de arte visual que empregam imagens em movimento para imi
 - O banco de dados de filmes constantemente atualizado é o refúgio perfeito para todos os cinéfilos apaixonados.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/braflix.video/)
 
+### ▶️ [TudoHD](https://tudohd.online/)
+- [Resultados de segurança da URL](https://www.urlvoid.com/scan/tudohd.online/)
+
 ### ▶️ [Mega Filmes HD](https://www.megafilmeshds.net/)
 
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/megafilmeshds.net/)

--- a/docs/pages/jogos.md
+++ b/docs/pages/jogos.md
@@ -222,11 +222,6 @@ Os jogos requerem interação com uma interface de usuário ou dispositivo de en
 - Fornecem jogos DRM-FREE de fontes que foram cuidadosamente examinadas antes de serem disponibilizadas para download.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/freegogpcgames.com/)
 
-### 🧲 [Steam Preta](https://steampreta.com) - Necessário Cadastro
-
-- Site Nacional que traz jogos diversos de várias fontes confiáveis com links para download sem anúncios.
-- [Resultados de segurança da URL](https://www.urlvoid.com/scan/steampreta.com/)
-
 ### 🧲 [KaOsKrew](https://kaoskrew.org/)
 
 - Rippers da velha escola que, pelo menos nas últimas duas décadas, produziram Rips e Repacks em sua própria velocidade.

--- a/docs/pages/softwares.md
+++ b/docs/pages/softwares.md
@@ -120,7 +120,7 @@ Software é uma coleção de programas de computador junto com arquivos de supor
 - Recurso para Windows, Android e Mac OS, fornecendo acesso direto a montes de conteúdo crackeado.
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/pesktop.com/)
 
-### 🌟 [RSLOAD](https://rsload.net/) • Interface em russo
+### [RSLOAD](https://rsload.net/) / [⚠️ Nota Importante](https://rentry.co/FileCR-Aviso) • Interface em russo
 
 - Oferece acesso aos arquivos das versões mais recentes do app e sempre mudando e melhorando para acompanhar os tempos.
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/rsload.net/)

--- a/docs/pages/softwares.md
+++ b/docs/pages/softwares.md
@@ -20,7 +20,7 @@ Software é uma coleção de programas de computador junto com arquivos de supor
 - Estão disponíveis centenas de novos modelos After Effects e Premiere Pro, incluindo efeitos sonoros.
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/aedownload.com/)
 
-### 🔗 [ALLPCWorld](https://allpcworld.com/)
+### 🔗 [ALLPCWorld](https://allpcworld.com/) / ⚠️
 
 - Baixe o software mais recente com apenas um clique e instalação rápida.
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/allpcworld.com/)


### PR DESCRIPTION
Filmes e TV:
* Adicionado BluDV (com estrela).
* Adicionado Torrent dos Filmes.
* Adicionado TudoHD de volta.

Software:
* Aviso no RSLoad e AllPCWorld.

> Motivo:
![image](https://github.com/c-pirataria/megathread/assets/71022656/06f575ec-b8a5-4c52-929e-19185ae0f1c5)
https://fmhy.net/unsafesites

Jogos:
* Removido Steam Preta.

> Motivo:
O site da upload de builds da IGGGAMES.
Exemplo: https://steampreta.com/files/file/264-manor-lords-v07955-igggames/

Vou adicionar e remover mais coisa provavelmente por isso que o PR essa em draft.