### PR TITLE
Yugenanime e AnimePahe

### DIFF
--- a/docs/pages/anime.md
+++ b/docs/pages/anime.md
@@ -71,7 +71,7 @@ Anime é um tipo de trabalho animado desenhado à mão criado no Japão, embora 
 - Este site tem uma interface elegante, o maior arquivo de conteúdo impressionante de anime gratuito online.
 - [URL Resultados de Segurança](https://www.urlvoid.com/scan/anime-owl.net/)
 
-### 🐐 [AnimePahe](https://animepahe.ru/)
+### ▶️ [AnimePahe](https://animepahe.ru/)
 
 - Acesso sem esforço a milhares de animes. Fluxo confiável com uso mínimo de dados e atualizações dos maiores lançamentos de torrent.
 - [Resultados de Segurança URL](https://www.urlvoid.com/scan/animepahe.ru/)
@@ -161,7 +161,7 @@ Anime é um tipo de trabalho animado desenhado à mão criado no Japão, embora 
 - Assista a uma variedade de desenhos animados e anime gratuitamente no site em HD incrível.
 - [URL Safety Results](https://www.urlvoid.com/scan/wcofun.org/)
 
-### ▶️ [YugenAnime](https://yugenanime.tv/)
+### 🌟 [YugenAnime](https://yugenanime.tv/)
 
 - Acompanhe, encontre, compartilhe e veja anime de alta qualidade. Se procura um serviço confiável e seguro, já o encontrou.
 - [Resultados de Segurança URL](https://www.urlvoid.com/scan/yugenanime.tv/)

--- a/docs/pages/anime.md
+++ b/docs/pages/anime.md
@@ -71,11 +71,6 @@ Anime é um tipo de trabalho animado desenhado à mão criado no Japão, embora 
 - Este site tem uma interface elegante, o maior arquivo de conteúdo impressionante de anime gratuito online.
 - [URL Resultados de Segurança](https://www.urlvoid.com/scan/anime-owl.net/)
 
-### ▶️ [AnimePahe](https://animepahe.ru/)
-
-- Acesso sem esforço a milhares de animes. Fluxo confiável com uso mínimo de dados e atualizações dos maiores lançamentos de torrent.
-- [Resultados de Segurança URL](https://www.urlvoid.com/scan/animepahe.ru/)
-
 ### ▶️ [AnimeRealms](https://www.animerealms.org/)
 
 - Assista anime online grátis em HD e em dispositivos móveis. Todas as séries e filmes estão em muito boa qualidade.

--- a/docs/pages/anime.md
+++ b/docs/pages/anime.md
@@ -49,49 +49,6 @@ Anime é um tipo de trabalho animado desenhado à mão criado no Japão, embora 
 - Acompanhe, encontre, compartilhe e veja anime de alta qualidade. Se procura um serviço confiável e seguro, já o encontrou.
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/yugenanime.tv/)
 
-## 📑 2 ➜ Downloads diretos
-
-### 🔗 [Anime Tosho](https://animetosho.org/)
-
-- Serviço gratuito e totalmente automatizado que espelha a maioria dos torrents
-- Nyaa e Tokyo Toshokan em vários provedores de hospedagem de arquivos de download direto.
-- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/animetosho.org/)
-
-### [AnimeOut](https://www.animeout.xyz/)
-
-- Pesquisa entre milhares de títulos de anime codificados que são oferecidos em 720p e 1080p.
-- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/animeout.xyz/)
-
-### [ChauThanh](https://chauthanh.info/)
-
-- Baixe anime, drama e trilhas sonoras gratuitamente. Obtenha arquivos e links de alta qualidade para mais de 5000 séries.
-- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/chauthanh.info/)
-
-### [Flugel Anime](https://flugel-anime.com/)
-
-- Arquivo extenso de nyaa.si. Desfrute de downloads muito rápidos, permitindo-lhe desfrutar das suas séries de anime favoritas.
-- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/flugel-anime.com)
-
-### [Hi10 Anime](https://hi10anime.com/) - Necessário Registro
-
-- Oferecendo o menor tamanho de arquivo, mas codificações de anime da mais alta qualidade, dependendo do conteúdo do anime.
-- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/hi10anime.com/)
-
-### [Kayoanime](https://kayoanime.com/) - Juntar-se ao Grupo Google
-
-- Construído com amor, este site é uma comunidade para fãs de anime onde os utilizadores podem partilhar atualizações, notícias e obter downloads de novos animes.
-- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/kayoanime.com/)
-
-### [NoobSubs](https://www.noobsubs.com/)
-
-- Oferece anime para download direto com duas faixas de áudio em inglês. Torrents também disponíveis.
-- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/noobsubs.com/)
-
-### [Tokyo Insider](https://www.tokyoinsider.com/)
-
-- Site fácil de navegar e uma grande coleção de séries de anime, incluindo downloads de alguns dos subbers mais populares.
-- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/tokyoinsider.com/)
-
 ## 📑 3 ➜ Torrents
 
 ### 🧲 [AniDex](https://anidex.info/)
@@ -103,6 +60,12 @@ Anime é um tipo de trabalho animado desenhado à mão criado no Japão, embora 
 
 - Tracker de torrent fácil e descomplicado, onde você pode encontrar os mais novos torrents relacionados a animes japoneses, bem como alguns dramas, mangás e músicas.
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/anirena.com/)
+
+### 🧲 [Anime Tosho](https://animetosho.org/)
+
+- Serviço gratuito e totalmente automatizado que espelha a maioria dos torrents
+- Nyaa e Tokyo Toshokan em vários provedores de hospedagem de arquivos de download direto.
+- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/animetosho.org/)
 
 ### 🧲 [Anime no Sekai](https://www.ansktracker.net/) | ANSK
 

--- a/docs/pages/anime.md
+++ b/docs/pages/anime.md
@@ -117,5 +117,3 @@ Anime é um tipo de trabalho animado desenhado à mão criado no Japão, embora 
 ## Está buscando apps para assistir/baixar **Anime** no celular?
 
 ➜ Confira nosso tópico sobre 📱 [Mobile](mobile#📑-➜-anime-e-manga)
-
-➜ Confira essa lista para mais sites para assistir animes: [https://pastelink.net/animes](https://pastelink.net/animes)

--- a/docs/pages/anime.md
+++ b/docs/pages/anime.md
@@ -11,30 +11,16 @@ Anime é um tipo de trabalho animado desenhado à mão criado no Japão, embora 
 
 ## 📑 1 ➜ Streaming
 
-### ▶️ [123anime](https://123anime.info/)
+### 🌟 [Better Anime](https://betteranime.net/)
 
-- Fácil acesso a uma boa seleção de anime. Fluxo confiável e atualizações dos lançamentos mais recentes.
-- [Resultados de Segurança URL](https://www.urlvoid.com/scan/123anime.info/)
+- O famoso **Better Anime** que está com DMCA mas está funcionando normalmente pelo app ou pelo site logando com sua conta, se não logar ele não vai funcionar.
+- [Resultados de Segurança URL](https://www.urlvoid.com/scan/betteranime.net/)
 
 ### ▶️ [4anime](https://4anime.gg/)
 
 - Após o encerramento do 4anime original, esta é uma alternativa incrivelmente rápida onde se pode ver anime e espetáculos.
-- [URL Safety Results](https://www.urlvoid.com/scan/4anime.gg/)
-
-### ▶️ [AllAnime](https://allanime.co/)
-
-- Um recurso confiável, que recolhe inúmeros sites diferentes com várias opções.
-- [Resultados de Segurança URL](https://www.urlvoid.com/scan/allanime.co/)
-
-### ▶️ [AniPulse](https://anipulse.to/)
-
-- Um paraíso para os amantes de anime, que oferece uma boa variedade de conteúdos cativantes de todos os gêneros.
-- [URL Resultados de Segurança](https://www.urlvoid.com/scan/anipulse.to/)
-
-### ▶️ [AniWave](https://aniwave.to/)
-
-- Com uma forte ênfase em títulos de anime em uma variedade de gêneros, você pode descobrir praticamente qualquer série que você deseja.
-- [URL Safety Results](https://www.urlvoid.com/scan/aniwave.to/)
+- Apesar do site ser gringo geralmente animes populares tem legendas em PT-BR.
+- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/4anime.gg/)
 
 ### ▶️ [Animes House](https://animeshouse.app/)
 
@@ -44,117 +30,19 @@ Anime é um tipo de trabalho animado desenhado à mão criado no Japão, embora 
 ### ▶️ [Animeflix](https://animeflix.gg/) / [2](https://animeflix.domains/)
 
 - Site muito bom para streaming gratuito de anime em inglês legendado e dublado.
-- [URL Safety Results](https://www.urlvoid.com/scan/animeflix.gg/)
-
-### ▶️ [Animefox](https://animefox.mobi/)
-
-- Assista anime online grátis em HD e em dispositivos móveis. Todas as séries e filmes estão em muito boa qualidade.
-- [URL Safety Results](https://www.urlvoid.com/scan/animefox.mobi/)
-
-### ▶️ [AnimeFrenzy](https://animefrenzy.cc/)
-
-- Desfrute do melhor serviço de streaming de anime e encontre o seu título favorito na nossa grande coleção de obras.
-- [URL Resultados de Segurança](https://www.urlvoid.com/scan/animefrenzy.cc/)
-
-### ▶️ [AnimeHub](https://animehub.ac/)
-
-- É altamente recomendável não perder este site onde se pode assistir anime online em alta definição.
-- [URL Resultados de Segurança](https://www.urlvoid.com/scan/animehub.ac/)
-
-### ▶️ [AnimeNana](https://animenana.com/)
-
-- Servidores de streaming super rápidos para o seu anime favorito, com os últimos lançamentos.
-- [URL Resultados de Segurança](https://www.urlvoid.com/scan/animenana.com/)
-
-### ▶️ [AnimeOwl](https://anime-owl.net/)
-
-- Este site tem uma interface elegante, o maior arquivo de conteúdo impressionante de anime gratuito online.
-- [URL Resultados de Segurança](https://www.urlvoid.com/scan/anime-owl.net/)
-
-### ▶️ [AnimeRealms](https://www.animerealms.org/)
-
-- Assista anime online grátis em HD e em dispositivos móveis. Todas as séries e filmes estão em muito boa qualidade.
-- [URL Safety Results](https://www.urlvoid.com/scan/animerealms.org/)
-
-### ▶️ [AnimeSuge](https://animesuge.to/)
-
-- Servidores de streaming rápidos que permitem ver o seu anime favorito. O material é atualizado todos os dias.
-- [URL Resultados de Segurança](https://www.urlvoid.com/scan/animesuge.to/)
-
-### ▶️ [AnimeXin](https://animexin.vip/) - Donghua
-
-- Site exclusivamente focado na série Donghua + fansub original. Frequentemente hospeda material no sempre poderoso YouTube.
-- [Resultados de Segurança URL](https://www.urlvoid.com/scan/animexin.vip/)
-
-### ▶️ [Anitaku](https://anitaku.to/)
-
-- Por ser tão simples, basta escolher um episódio e começar a ver.
-- [URL Resultados de Segurança](https://www.urlvoid.com/scan/anitaku.to/)
-
-### ▶️ [AniXen](https://anixen.vercel.app/)
-
-- Apresenta uma série de títulos de anime de vários gêneros, acessíveis para exploração.
-- [URL Resultados de Segurança](https://www.urlvoid.com/scan/anixen.vercel.app/)
-
-### ▶️ [Anix](https://anix.to/)
-
-- Influencia-se na conhecida plataforma AniMixPlay que apresenta um layout minimalista.
-- [URL Resultados de Segurança](https://www.urlvoid.com/scan/anix.to/)
-
-### 🌟 [Better Anime](https://betteranime.net/)
-
-- O famoso **Better Anime** que está com DMCA mas está funcionando normalmente pelo app ou pelo site logando com sua conta, se não logar ele não vai funcionar.
-- [Resultados de Segurança URL](https://www.urlvoid.com/scan/betteranime.net/)
-
-### ▶️ [Dramalama](https://dramalama.netlify.app/) / [2](https://dramalama.vercel.app/)
-
-- Plataforma para assistir anime, kdramas, além de mangás e filmes.
-- [URL Safety Results](https://www.urlvoid.com/scan/dramalama.netlify.app/)
-
-### ▶️ [HiAnime](https://hianime.to/)
-
-- Site de streaming muito rápido onde também se pode baixar anime legendado ou dublado em qualidade super HD.
-- [URL Safety Results](https://www.urlvoid.com/scan/hianime.to/)
+- Apesar do site ser gringo geralmente animes populares tem legendas em PT-BR.
+- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/animeflix.gg/)
 
 ### ▶️ [Hinata Soul](https://www.hinatasoul.com/)
 
 - Ótimo site que oferece opções HD e Full HD para assistir.
 - [Resultados de Segurança URL](https://www.urlvoid.com/scan/hinatasoul.com/)
 
-### ▶️ [HolyMix](https://holymix.netlify.app/)
-
-- Anime de alta qualidade, onde os espectadores podem desfrutar de streaming sem anúncios.
-- [URL Resultados de Segurança](https://www.urlvoid.com/scan/holymix.netlify.app/)
-
-### ▶️ [Kaido](https://kaido.to/)
-
-- Site de streaming de anime confiável e rápido. Beneficie de características excepcionais como a resolução HD.
-- [Resultados de Segurança URL](https://www.urlvoid.com/scan/kaido.to/)
-
 ### ▶️ [KickAssAnime](https://kickassanime.am/)
 
 - Fiável para novos lançamentos com excelente qualidade, mas não é a melhor seleção para anime mais antigo.
+- Apesar do site ser gringo geralmente animes populares tem legendas em PT-BR.
 - [Resultados de Segurança URL](https://www.urlvoid.com/scan/kickassanime.am/)
-
-### ▶️ [Myanime](https://myanime.live/) - Donghua
-
-- Existem várias opções de streaming de donghua com legendas em inglês acessíveis neste sítio web.
-- [URL Resultados de Segurança](https://www.urlvoid.com/scan/myanime.live/)
-
-### ▶️ [Nanime](https://www.nanime.one/)
-
-- Pode assistir a anime online gratuitamente neste serviço de streaming, e certamente encontrará mais programas e filmes aqui.
-- [URL Resultados de Segurança](https://www.urlvoid.com/scan/nanime.one/)
-
-### ▶️ [Playtaku](https://gogohd.net/)
-
-- Veio ao sítio certo se está à procura de algo novo e intrigante.
-- [URL Resultados de Segurança](https://www.urlvoid.com/scan/anihdplay.com/)
-
-### ▶️ [WcoFun](https://wcofun.org/) / [2](https://www.wco.tv/)
-
-- Assista a uma variedade de desenhos animados e anime gratuitamente no site em HD incrível.
-- [URL Safety Results](https://www.urlvoid.com/scan/wcofun.org/)
 
 ### 🌟 [YugenAnime](https://yugenanime.tv/)
 

--- a/docs/pages/anime.md
+++ b/docs/pages/anime.md
@@ -14,7 +14,7 @@ Anime é um tipo de trabalho animado desenhado à mão criado no Japão, embora 
 ### 🌟 [Better Anime](https://betteranime.net/)
 
 - O famoso **Better Anime** que está com DMCA mas está funcionando normalmente pelo app ou pelo site logando com sua conta, se não logar ele não vai funcionar.
-- [Resultados de Segurança URL](https://www.urlvoid.com/scan/betteranime.net/)
+- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/betteranime.net/)
 
 ### ▶️ [4anime](https://4anime.gg/)
 
@@ -25,7 +25,7 @@ Anime é um tipo de trabalho animado desenhado à mão criado no Japão, embora 
 ### ▶️ [Animes House](https://animeshouse.app/)
 
 - Aparentemente ressurgiu das cinzas ou é um clone do antigo Animes House.
-- [Resultados de Segurança URL](https://www.urlvoid.com/scan/animeshouse.app/)
+- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/animeshouse.app/)
 
 ### ▶️ [Animeflix](https://animeflix.gg/) / [2](https://animeflix.domains/)
 
@@ -36,75 +36,73 @@ Anime é um tipo de trabalho animado desenhado à mão criado no Japão, embora 
 ### ▶️ [Hinata Soul](https://www.hinatasoul.com/)
 
 - Ótimo site que oferece opções HD e Full HD para assistir.
-- [Resultados de Segurança URL](https://www.urlvoid.com/scan/hinatasoul.com/)
+- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/hinatasoul.com/)
 
 ### ▶️ [KickAssAnime](https://kickassanime.am/)
 
 - Fiável para novos lançamentos com excelente qualidade, mas não é a melhor seleção para anime mais antigo.
 - Apesar do site ser gringo geralmente animes populares tem legendas em PT-BR.
-- [Resultados de Segurança URL](https://www.urlvoid.com/scan/kickassanime.am/)
+- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/kickassanime.am/)
 
 ### 🌟 [YugenAnime](https://yugenanime.tv/)
 
 - Acompanhe, encontre, compartilhe e veja anime de alta qualidade. Se procura um serviço confiável e seguro, já o encontrou.
-- [Resultados de Segurança URL](https://www.urlvoid.com/scan/yugenanime.tv/)
+- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/yugenanime.tv/)
 
 ## 📑 2 ➜ Downloads diretos
 
 ### 🔗 [Anime Tosho](https://animetosho.org/)
 
 - Serviço gratuito e totalmente automatizado que espelha a maioria dos torrents
-
-Nyaa e Tokyo Toshokan em vários provedores de hospedagem de arquivos de download direto.
-
-- [Resultados de Segurança URL](https://www.urlvoid.com/scan/animetosho.org/)
+- Nyaa e Tokyo Toshokan em vários provedores de hospedagem de arquivos de download direto.
+- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/animetosho.org/)
 
 ### [AnimeOut](https://www.animeout.xyz/)
 
 - Pesquisa entre milhares de títulos de anime codificados que são oferecidos em 720p e 1080p.
-- [Resultados de Segurança URL](https://www.urlvoid.com/scan/animeout.xyz/)
+- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/animeout.xyz/)
 
 ### [ChauThanh](https://chauthanh.info/)
 
 - Baixe anime, drama e trilhas sonoras gratuitamente. Obtenha arquivos e links de alta qualidade para mais de 5000 séries.
-- [Resultados de Segurança URL](https://www.urlvoid.com/scan/chauthanh.info/)
+- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/chauthanh.info/)
 
 ### [Flugel Anime](https://flugel-anime.com/)
 
 - Arquivo extenso de nyaa.si. Desfrute de downloads muito rápidos, permitindo-lhe desfrutar das suas séries de anime favoritas.
-- [Resultados de Segurança URL](https://www.urlvoid.com/scan/flugel-anime.com)
+- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/flugel-anime.com)
 
-### [Hi10 Anime](https://hi10anime.com/) - Registo
+### [Hi10 Anime](https://hi10anime.com/) - Necessário Registro
 
 - Oferecendo o menor tamanho de arquivo, mas codificações de anime da mais alta qualidade, dependendo do conteúdo do anime.
-- [URL Safety Results](https://www.urlvoid.com/scan/hi10anime.com/)
+- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/hi10anime.com/)
 
 ### [Kayoanime](https://kayoanime.com/) - Juntar-se ao Grupo Google
 
 - Construído com amor, este site é uma comunidade para fãs de anime onde os utilizadores podem partilhar atualizações, notícias e obter downloads de novos animes.
-- [Resultados de Segurança URL](https://www.urlvoid.com/scan/kayoanime.com/)
+- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/kayoanime.com/)
 
 ### [NoobSubs](https://www.noobsubs.com/)
 
 - Oferece anime para download direto com duas faixas de áudio em inglês. Torrents também disponíveis.
-- [Resultados de Segurança URL](https://www.urlvoid.com/scan/noobsubs.com/)
+- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/noobsubs.com/)
 
 ### [Tokyo Insider](https://www.tokyoinsider.com/)
 
 - Site fácil de navegar e uma grande coleção de séries de anime, incluindo downloads de alguns dos subbers mais populares.
-- [Resultados de Segurança URL](https://www.urlvoid.com/scan/tokyoinsider.com/)
+- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/tokyoinsider.com/)
 
 ## 📑 3 ➜ Torrents
 
 ### 🧲 [AniDex](https://anidex.info/)
 
 - Rastreador e indexador que atende a vários idiomas e mídias, mas é mais usado e conhecido por grupos de fãs de anime ingleses.
-- [Resultados de Segurança URL](https://www.urlvoid.com/scan/anidex.info/)
+- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/anidex.info/)
 
 ### 🧲 [AniRena](https://www.anirena.com/)
 
 - Tracker de torrent fácil e descomplicado, onde você pode encontrar os mais novos torrents relacionados a animes japoneses, bem como alguns dramas, mangás e músicas.
-- [Resultados de Segurança URL](https://www.urlvoid.com/scan/anirena.com/)
+- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/anirena.com/)
 
 ### 🧲 [Anime no Sekai](https://www.ansktracker.net/) | ANSK
 
@@ -112,17 +110,17 @@ Nyaa e Tokyo Toshokan em vários provedores de hospedagem de arquivos de downloa
 
 ### 🧲 [Dark Mahou](https://darkmahou.org/)
 
-- [Resultados de Segurança URL](https://www.urlvoid.com/scan/darkmahou.org/)
+- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/darkmahou.org/)
 
 ### 🧲 [Erai-raws](https://www.erai-raws.info/) • Cadastre-se
 
 - Certamente um dos principais grupos de legendas que prioriza a uniformidade acima de tudo.
-- [Resultados de Segurança URL](https://www.urlvoid.com/scan/erai-raws.info/)
+- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/erai-raws.info/)
 
 ### 🧲 [Nyaa.si](https://nyaa.si/) / [2](https://nyaa.land/)
 
 - Site de torrent muito conhecido com foco em anime, dedicado à mídia do Leste Asiático (_japonês, chinês e coreano_).
-- [Resultados de Segurança URL](https://www.urlvoid.com/scan/nyaa.si/)
+- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/nyaa.si/)
 
 ### 🧲 [Projeto AcgnX](https://share.acgnx.se/) • Interface em chinês
 


### PR DESCRIPTION
Solicito diminuir o status e até se possível remover o link do AnimePahe por encaminhar automaticamente para sites indesejados e com injeção de malware traiçoeiro.

Recomendo aumentarem o status do Yugenanime.